### PR TITLE
Fix Change the progress bar to operate normally

### DIFF
--- a/Timer.js
+++ b/Timer.js
@@ -23,8 +23,8 @@ class Timer extends Component{
         };
         this.defaultStyles = {
             view: {
-                flexDirection: 'row', 
-                justifyContent: 'space-between', 
+                flexDirection: 'row',
+                justifyContent: 'space-between',
                 margin: 10
               },
               highlight: {
@@ -54,37 +54,48 @@ class Timer extends Component{
         this.tick = this.tick.bind(this);
     }
 
-    tick() {  
-        if(this.state.initialState) {
-          this.setState({ 
-            initialState: false,
-            counter: this.state.interval, 
-            originalCounter: this.state.interval,
-            play: false, 
-            stop: !this.state.stop, 
-            pause: true,
-            resume: false
-          });
+    tick() {
+
+        if (this.state.initialState) {
+
+            const originalCounter = this.state.interval;
+
+            const initCounter = originalCounter - 1;
+
+            const initProgress = 1 - (initCounter / originalCounter);
+
+            this.setState({
+                initialState: false,
+                counter: initCounter,
+                originalCounter: originalCounter,
+                play: false,
+                stop: !this.state.stop,
+                pause: true,
+                resume: false,
+                progress: initProgress,
+            });
+
+            return;
         }
 
-        if(this.state.counter <= 0) {
-            this.setState({ 
-                counter: 0,
-                progress: 0,
-                play: true,
-                pause: false,
-                resume: false
+        if (this.state.counter <= 0) {
+
+            this.setState({
+                counter: 0, progress: 0, play: true, pause: false, resume: false,
             });
             this.releaseResources();
         } else {
-            this.setState({ 
-                counter: this.state.counter - 1,
-                progress: 1 - this.state.counter/this.state.originalCounter
+
+            const counter = this.state.counter - 1;
+
+            const progress = 1 - (counter / this.state.originalCounter);
+
+            this.setState({
+                counter: counter,
+                progress: progress,
             });
 
-            timer.setInterval(this, 'tick', () => this.tick(), 1000);
-        }  
-            
+        }
     }
 
     _displayText(){
@@ -135,7 +146,7 @@ class Timer extends Component{
             return 'Pause'
         else if(this.state.resume)
             return 'Resume'
-        else 
+        else
             return 'Start'
     }
 


### PR DESCRIPTION
### Explanation

I changed the "tick" method.

I found that the progress bar and the time are not synchronized during init at first.

Therefore, when init is executed, the method is immediately terminated and then changed to be executed again.

Also, since the progress bar does not go to the end, that part has been changed.

Please check the attached video.

### Before fixing

https://user-images.githubusercontent.com/53357210/208228353-a3eca953-2228-45e7-a5b6-9313f0383253.mov



### After fixing


https://user-images.githubusercontent.com/53357210/208228378-b238ab7f-1c36-4e59-8390-6d0fe2811a13.mov
