### PR TITLE
Fix Time values are not set when rendering

### DIFF
--- a/Timer.js
+++ b/Timer.js
@@ -164,8 +164,7 @@ class Timer extends Component{
             timer.clearInterval(this);
             timer.cancelAnimationFrame(this);
             this.setState({
-            counter: 0,
-                originalCounter: 0,
+                counter: this.state.originalCounter,
                 progress: 0,
                 pause: false,
                 resume: false,

--- a/Timer.js
+++ b/Timer.js
@@ -12,7 +12,7 @@ class Timer extends Component{
     constructor(props){
         super(props);
 
-        if (this.props.remainingTime == null || this.props.remainingTime === 0) {
+        if (this.props.remainingTime == null) {
             throw Error("Setting the remainingTime value is required.");
         }
 

--- a/Timer.js
+++ b/Timer.js
@@ -166,9 +166,11 @@ class Timer extends Component{
             this.setState({
                 counter: this.state.originalCounter,
                 progress: 0,
+                play: true,
                 pause: false,
+                stop: true,
                 resume: false,
-            })
+            });
         }catch(err){console.log(err)}
     }
 

--- a/Timer.js
+++ b/Timer.js
@@ -11,6 +11,25 @@ import timer from 'react-native-timer';
 class Timer extends Component{
     constructor(props){
         super(props);
+
+        if (this.props.remainingTime == null || this.props.remainingTime === 0) {
+            throw Error("Setting the remainingTime value is required.");
+        }
+
+        const remainingTime = this.props.remainingTime;
+
+        this.state = {
+            counter: remainingTime,
+            originalCounter: remainingTime,
+            initialState: true,
+            progress: 0,
+            play: true,
+            pause: false,
+            stop: true,
+            resume: false,
+            interval: remainingTime,
+        };
+
         this.state = {
           counter: 0,
           originalCounter: 0,
@@ -107,7 +126,6 @@ class Timer extends Component{
             //this._stop();
             this.setState({
                 initialState: true,
-                interval: this.props.remainingTime,
                 play: false,
                 pause: true,
                 resume: false

--- a/Timer.js
+++ b/Timer.js
@@ -30,16 +30,6 @@ class Timer extends Component{
             interval: remainingTime,
         };
 
-        this.state = {
-          counter: 0,
-          originalCounter: 0,
-          initialState: true,
-          progress:0,
-          play: true,
-          pause: false,
-          stop: true,
-          resume: false,
-        };
         this.defaultStyles = {
             view: {
                 flexDirection: 'row',


### PR DESCRIPTION
### Explanation

I think the "remainingTime" value should be set first.

The "remainingTime" value is not set on first display.

Set the "remainingTime" value initially.

Also if it is null or 0 an exception will be thrown.


### issue list

#6 
#7 

### Before fixing

<img width="533" alt="고치기전" src="https://user-images.githubusercontent.com/53357210/208278529-27fac131-29c1-48d6-844a-7f3391ac62b5.png">


### After fixing

<img width="474" alt="고친후" src="https://user-images.githubusercontent.com/53357210/208278532-350d1f17-8cb1-4d37-8fc5-d6fd97ffd0a4.png">

